### PR TITLE
WIP: Add SDK class and methods based on axios and qs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-typescript"],
+  "plugins": ["@babel/plugin-transform-runtime"]
+}

--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,3 @@
+API_BASE_URL=http://headless.test/api/1.0
+API_NON_PREVIEW_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+API_PREVIEW_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+    root: true,
+    env: {
+        browser: true,
+        node: true,
+    },
+    extends: ['prettier', 'plugin:prettier/recommended'],
+    plugins: ['prettier'],
+    rules: {
+        'no-undef': 'off',
+        'no-use-before-define': 'off',
+    },
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.env
+
 # Logs
 logs
 *.log

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "semi": false,
+  "printWidth": 120,
+  "tabWidth": 4
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "singleQuote": true,
   "semi": false,
   "printWidth": 120,
-  "tabWidth": 4
+  "tabWidth": 4,
+  "bracketSpacing": true
 }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,62 @@ yarn add @roadiz/abstract-api-client
 }
 ```
 
+### Customize Roadiz API client against your own API schema
+
+- Download latest `d.ts` definition file from Roadiz backoffice
+- Extend `RoadizApi` class
+- Add `get{YourNodeType}` methods for each of your node-types. RoadizApi methods use Typescript generics to easily declare
+your return type inside collections: `this.getNodesSourcesForType<NSPage>('page', params)` 
+- Other methods can be overridden without specifying type
+
+```ts
+export default class MyAwesomeRoadizApi extends RoadizApi {
+    /*
+     * Page node-type
+     */
+    getPages(params: RoadizApiNSParams) {
+        return this.getNodesSourcesForType<NSPage>('page', params)
+    }
+    getPagesTags(params: RoadizApiTagsParams) {
+        return this.getTagsForType('page', params)
+    }
+    
+    /*
+     * BlogPost node-type
+     */
+    getBlogPosts(params: RoadizApiNSParams) {
+        // Additional default params…
+        params = {
+            order: {
+                publishedAt: 'DESC'
+            },
+            ...params,
+        }
+        return this.getNodesSourcesForType<NSBlogPost>('blog-post', params)
+    }
+    getBlogPostsTags(params: RoadizApiTagsParams) {
+        return this.getTagsForType('blog-post', params)
+    }
+    getBlogPostsArchives(params: RoadizApiNSParams) {
+        return this.getArchivesForType('blog-post', params)
+    }
+}
+```
+
+### Fetch all URLs for a sitemap
+
+```ts
+const api = new HeadlessRoadizApi(
+    process.env.API_BASE_URL, 
+    process.env.API_NON_PREVIEW_API_KEY, 
+    false
+)
+
+return api.fetchAllUrlsForLocale('fr').then((urls: Array<string>) => {
+    // build your sitemap
+})
+```
+
 ## Test
 
 Tests use *jest* and require a working Roadiz headless API to fetch responses from. Copy `.env.dist` to `.env` 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,33 @@ return api.fetchAllUrlsForLocale('fr').then((urls: Array<string>) => {
 })
 ```
 
+### Get all alternative URLs for a node-source
+
+Alternative links are useful to build language navigation for each website page. It's based
+on HTTP response header `Link`.
+API `getAlternateLinks` method will return a `Array<AlternateLink>` from an `AxiosResponse`:
+
+```ts
+const api = new HeadlessRoadizApi(
+    process.env.API_BASE_URL, 
+    process.env.API_NON_PREVIEW_API_KEY, 
+    false
+)
+
+api.getSingleNodesSourcesByPath('/').then((response) => {
+    /*
+     * [{
+     *     url: '/',
+     *     locale: 'en'
+     * }, {
+     *     url: '/fr',
+     *     locale: 'fr'
+     * }]
+     */
+    api.getAlternateLinks(response)
+})
+```
+
 ## Test
 
 Tests use *jest* and require a working Roadiz headless API to fetch responses from. Copy `.env.dist` to `.env` 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ export default class MyAwesomeRoadizApi extends RoadizApi {
 ### Fetch all URLs for a sitemap
 
 ```ts
-const api = new HeadlessRoadizApi(
+const api = new MyAwesomeRoadizApi(
     process.env.API_BASE_URL, 
     process.env.API_NON_PREVIEW_API_KEY, 
     false
@@ -83,7 +83,7 @@ on HTTP response header `Link`.
 API `getAlternateLinks` method will return a `Array<AlternateLink>` from an `AxiosResponse`:
 
 ```ts
-const api = new HeadlessRoadizApi(
+const api = new MyAwesomeRoadizApi(
     process.env.API_BASE_URL, 
     process.env.API_NON_PREVIEW_API_KEY, 
     false

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # abstract-api-client
-Abstract API Typescript client interfaces and SDK
+Abstract API Typescript client interfaces and SDK.
+
+Based on *Axios* HTTP client.
 
 ## Usage
 
 ```json
-yarn add --dev @roadiz/abstract-api-client
+yarn add @roadiz/abstract-api-client
 ```
 
 ```json
@@ -16,4 +18,15 @@ yarn add --dev @roadiz/abstract-api-client
     ]
   }
 }
+```
+
+## Test
+
+Tests use *jest* and require a working Roadiz headless API to fetch responses from. Copy `.env.dist` to `.env` 
+and fill your server credentials.
+
+```
+yarn
+cp .env.dist .env
+yarn test
 ```

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,3 @@
 module.exports = {
-    presets: [
-        ['@babel/preset-env'],
-        '@babel/preset-typescript',
-    ]
+    presets: [['@babel/preset-env'], '@babel/preset-typescript'],
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    presets: [
+        ['@babel/preset-env'],
+        '@babel/preset-typescript',
+    ]
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-    presets: [['@babel/preset-env'], '@babel/preset-typescript'],
-}

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,3 +4,4 @@
 export * from './types/hydra'
 export * from './types/roadiz'
 export * from './types/roadiz-api'
+export * from './types/common'

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    setupFiles: [
+        'dotenv/config'
+    ],
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,3 @@
 module.exports = {
-    setupFiles: [
-        'dotenv/config'
-    ],
+    setupFiles: ['dotenv/config'],
 }

--- a/package.json
+++ b/package.json
@@ -24,15 +24,18 @@
   },
   "devDependencies": {
     "@babel/core": "^7.14.6",
+    "@babel/plugin-transform-runtime": "^7.14.5",
     "@babel/preset-env": "^7.14.7",
     "@babel/preset-typescript": "^7.14.5",
     "@types/jest": "^26.0.23",
+    "babel-core": "^6.26.3",
     "babel-jest": "^27.0.5",
     "dotenv": "^10.0.0",
     "eslint": "^7.29.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.0",
     "jest": "^27.0.5",
-    "prettier": "^2.3.1"
+    "prettier": "^2.3.1",
+    "regenerator-runtime": "^0.13.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,5 +14,14 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "axios": "^0.21.1"
+  },
+  "devDependencies": {
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-prettier": "^3.4.0",
+    "prettier": "^2.3.1",
+    "eslint": "^7.29.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadiz/abstract-api-client",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Roadiz abstract API Typescript client interfaces and SDK",
   "repository": {
     "url": "https://github.com/roadiz/abstract-api-client",

--- a/package.json
+++ b/package.json
@@ -15,13 +15,23 @@
   "publishConfig": {
     "access": "public"
   },
+  "scripts": {
+    "test": "jest"
+  },
   "dependencies": {
     "axios": "^0.21.1"
   },
   "devDependencies": {
+    "@babel/core": "^7.14.6",
+    "@babel/preset-env": "^7.14.7",
+    "@babel/preset-typescript": "^7.14.5",
+    "@types/jest": "^26.0.23",
+    "babel-jest": "^27.0.5",
+    "dotenv": "^10.0.0",
+    "eslint": "^7.29.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.0",
-    "prettier": "^2.3.1",
-    "eslint": "^7.29.0"
+    "jest": "^27.0.5",
+    "prettier": "^2.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "axios": "^0.21.1"
+    "axios": "^0.21.1",
+    "qs": "^6.10.1"
   },
   "devDependencies": {
     "@babel/core": "^7.14.6",

--- a/src/RoadizApi.ts
+++ b/src/RoadizApi.ts
@@ -9,6 +9,7 @@ export default class RoadizApi {
     protected axios: AxiosInstance
     protected apiKey: string
     protected preview: boolean
+    protected debug: boolean
 
     public constructor(baseURL: string, apiKey: string, preview: boolean = false, debug: boolean = false) {
         this.axios = axios.create();
@@ -18,11 +19,15 @@ export default class RoadizApi {
             'Accept': 'application/json',
         }
         this.axios.defaults.baseURL = baseURL
+        /*
+         * Use qs to allow array query params
+         */
         this.axios.defaults.paramsSerializer = (params) => {
             return qs.stringify(params)
         }
         this.apiKey = apiKey;
         this.preview = preview;
+        this.debug = debug;
 
         this.axios.interceptors.request.use((config) => {
             config.params = config.params || {}
@@ -30,15 +35,11 @@ export default class RoadizApi {
             if (this.preview) {
                 config.params['_preview'] = this.preview
             }
+            if (this.debug) {
+                console.log('Axios Request', JSON.stringify(config, null, 2))
+            }
             return config
         })
-
-        if (debug) {
-            this.axios.interceptors.request.use(request => {
-                console.log('Axios Request', JSON.stringify(request, null, 2))
-                return request
-            })
-        }
     }
 
     public getCommonContent<T = CommonContentResponse>(params: RoadizApiNSParams): Promise<AxiosResponse<T>> {

--- a/src/RoadizApi.ts
+++ b/src/RoadizApi.ts
@@ -1,0 +1,46 @@
+import {RoadizApiNSParams, RoadizApiSearchParams, RoadizApiTagsParams} from '../types/roadiz-api'
+import { HydraCollection } from '../types/hydra'
+import {RoadizNodesSources, RoadizSearchResultItem, RoadizTag} from '../types/roadiz'
+import { AxiosInstance, AxiosResponse } from 'axios'
+import { CommonContentResponse } from "../types/common";
+
+export default class RoadizApi {
+    protected axios: AxiosInstance
+
+    constructor(axios: AxiosInstance) {
+        this.axios = axios;
+    }
+
+    getCommonContent(params: RoadizApiNSParams): Promise<AxiosResponse<CommonContentResponse>> {
+        return this.axios.get<CommonContentResponse>('/common', { params })
+    }
+
+    getNodesSources(params: RoadizApiNSParams): Promise<AxiosResponse<HydraCollection<RoadizNodesSources>>> {
+        return this.axios.get<HydraCollection<RoadizNodesSources>>(`/nodes-sources`, {
+            params,
+        })
+    }
+
+    getNodesSourcesByPath(path: string): Promise<AxiosResponse<RoadizNodesSources>> {
+        return this.axios.get<RoadizNodesSources>('/nodes-sources/by-path', {
+            params: {
+                path: '/' + path || '',
+            },
+        })
+    }
+
+    /*
+     * Returns RoadizSearchResultItem if search param is longer than 4 chars. Else return directly a RoadizNodesSources
+     */
+    searchNodesSourcesByPath(params: RoadizApiSearchParams): Promise<AxiosResponse<HydraCollection<RoadizSearchResultItem | RoadizNodesSources>>> {
+        return this.axios.get<HydraCollection<RoadizSearchResultItem | RoadizNodesSources>>('/nodes-sources/search', {
+            params,
+        })
+    }
+
+    getTagsForType(type: string, params: RoadizApiTagsParams): Promise<AxiosResponse<HydraCollection<RoadizTag>>> {
+        return this.axios.get<HydraCollection<RoadizTag>>(`/${type}/tags`, {
+            params,
+        })
+    }
+}

--- a/src/RoadizApi.ts
+++ b/src/RoadizApi.ts
@@ -1,8 +1,8 @@
 import {RoadizApiNSParams, RoadizApiSearchParams, RoadizApiTagsParams} from '../types/roadiz-api'
-import { HydraCollection } from '../types/hydra'
+import {ArchivesHydraCollection, HydraCollection} from '../types/hydra'
 import {RoadizNodesSources, RoadizSearchResultItem, RoadizTag} from '../types/roadiz'
-import { AxiosInstance, AxiosResponse } from 'axios'
-import { CommonContentResponse } from "../types/common";
+import {AxiosInstance, AxiosResponse} from 'axios'
+import {CommonContentResponse} from '../types/common'
 
 export default class RoadizApi {
     protected axios: AxiosInstance
@@ -12,7 +12,7 @@ export default class RoadizApi {
     }
 
     getCommonContent(params: RoadizApiNSParams): Promise<AxiosResponse<CommonContentResponse>> {
-        return this.axios.get<CommonContentResponse>('/common', { params })
+        return this.axios.get<CommonContentResponse>('/common', {params})
     }
 
     getNodesSources(params: RoadizApiNSParams): Promise<AxiosResponse<HydraCollection<RoadizNodesSources>>> {
@@ -40,6 +40,30 @@ export default class RoadizApi {
 
     getTagsForType(type: string, params: RoadizApiTagsParams): Promise<AxiosResponse<HydraCollection<RoadizTag>>> {
         return this.axios.get<HydraCollection<RoadizTag>>(`/${type}/tags`, {
+            params,
+        })
+    }
+
+    /*
+     * {
+     *     "hydra:member": {
+     *         "2021": {
+     *             "2021-06": "2021-06-01T00:00:00+02:00",
+     *             "2021-05": "2021-05-01T00:00:00+02:00",
+     *             "2021-04": "2021-04-01T00:00:00+02:00"
+     *         }
+     *     },
+     *     "hydra:totalItems": 1,
+     *     "@id": "/api/1.0/post/archives",
+     *     "@type": "hydra:Collection",
+     *     "hydra:view": {
+     *         "@id": "/api/1.0/post/archives?_locale=fr",
+     *         "@type": "hydra:PartialCollectionView"
+     *     }
+     * }
+     */
+    getArchivesForType(type: string, params: RoadizApiNSParams): Promise<AxiosResponse<ArchivesHydraCollection>> {
+        return this.axios.get<ArchivesHydraCollection>(`/${type}/archives`, {
             params,
         })
     }

--- a/src/RoadizApi.ts
+++ b/src/RoadizApi.ts
@@ -1,14 +1,30 @@
 import {RoadizApiNSParams, RoadizApiSearchParams, RoadizApiTagsParams} from '../types/roadiz-api'
 import {ArchivesHydraCollection, HydraCollection} from '../types/hydra'
 import {RoadizNodesSources, RoadizSearchResultItem, RoadizTag} from '../types/roadiz'
-import {AxiosInstance, AxiosResponse} from 'axios'
+import axios, {AxiosInstance, AxiosResponse} from 'axios'
 import {CommonContentResponse} from '../types/common'
 
 export default class RoadizApi {
     protected axios: AxiosInstance
+    protected apiKey: string
+    protected preview: boolean
 
-    constructor(axios: AxiosInstance) {
-        this.axios = axios;
+    constructor(baseURL: string, apiKey: string, preview: boolean = false, debug: boolean = false) {
+        this.axios = axios.create();
+        this.axios.defaults.withCredentials = false
+        this.axios.defaults.headers['X-Api-Key'] = apiKey
+        this.axios.defaults.baseURL = baseURL
+        this.apiKey = apiKey;
+        this.preview = preview;
+
+        this.axios.interceptors.request.use((config) => {
+            config.params = config.params || {}
+
+            if (this.preview) {
+                config.params['_preview'] = this.preview
+            }
+            return config
+        })
     }
 
     getCommonContent(params: RoadizApiNSParams): Promise<AxiosResponse<CommonContentResponse>> {

--- a/src/RoadizApi.ts
+++ b/src/RoadizApi.ts
@@ -1,4 +1,4 @@
-import {RoadizApiNSParams, RoadizApiSearchParams, RoadizApiTagsParams} from '../types/roadiz-api'
+import {AlternateLink, RoadizApiNSParams, RoadizApiSearchParams, RoadizApiTagsParams} from '../types/roadiz-api'
 import {ArchivesHydraCollection, HydraCollection} from '../types/hydra'
 import {RoadizNodesSources, RoadizSearchResultItem, RoadizTag} from '../types/roadiz'
 import axios, {AxiosInstance, AxiosResponse} from 'axios'
@@ -135,5 +135,26 @@ export default class RoadizApi {
         } while (active)
 
         return refs
+    }
+
+    getAlternateLinks(response: AxiosResponse): Array<AlternateLink> {
+        if (!response.headers.link) return []
+
+        return response.headers.link
+            .split(',')
+            .filter((link) => {
+                return link
+                    .split(';')
+                    .map((attribute) => attribute.trim())
+                    .includes('type="text/html"')
+            })
+            .map((link) => {
+                const attributes = link.split(';')
+
+                return {
+                    url: attributes[0].split('<').join('').split('>').join('').trim(),
+                    locale: attributes[2].split('hreflang="').join('').split('"').join('').trim(),
+                } as AlternateLink
+            })
     }
 }

--- a/tests/InheritingRoadizApi.test.ts
+++ b/tests/InheritingRoadizApi.test.ts
@@ -1,5 +1,5 @@
 import RoadizApi from '../src/RoadizApi'
-import {RoadizApiNSParams, RoadizApiTagsParams} from '../types/roadiz-api'
+import {AlternateLink, RoadizApiNSParams, RoadizApiTagsParams} from '../types/roadiz-api'
 import {NSNeutral, NSPage} from "./types/roadiz-app-20210623-220029"
 import {RoadizDocument} from "../types/roadiz";
 
@@ -47,6 +47,20 @@ test('Headless API: By path', () => {
         expect(response.data).toBeDefined()
         expect(response.data['@type']).toBe('Page')
         expect(response.data.url).toBe('/')
+    })
+})
+
+test('Headless API: Home alternate links', () => {
+    const api = new HeadlessRoadizApi(process.env.API_BASE_URL, process.env.API_NON_PREVIEW_API_KEY, false)
+
+    return api.getSingleNodesSourcesByPath('/').then((response) => {
+        expect(api.getAlternateLinks(response)).toStrictEqual([{
+            url: '/',
+            locale: 'en'
+        }, {
+            url: '/fr',
+            locale: 'fr'
+        }])
     })
 })
 

--- a/tests/InheritingRoadizApi.test.ts
+++ b/tests/InheritingRoadizApi.test.ts
@@ -1,0 +1,63 @@
+import RoadizApi from '../src/RoadizApi'
+import {RoadizApiNSParams} from '../types/roadiz-api'
+import {AxiosResponse} from "axios"
+import {HydraCollection} from '../types/hydra'
+import {NSNeutral, NSPage} from "./types/roadiz-app-20210623-220029"
+import {RoadizDocument} from "../types/roadiz";
+
+class HeadlessRoadizApi extends RoadizApi {
+    getPages(params: RoadizApiNSParams): Promise<AxiosResponse<HydraCollection<NSPage>>> {
+        return this.axios.get<HydraCollection<NSPage>>(`/page`, {
+            params,
+        })
+    }
+    getNeutrals(params: RoadizApiNSParams): Promise<AxiosResponse<HydraCollection<NSNeutral>>> {
+        return this.axios.get<HydraCollection<NSNeutral>>(`/neutral`, {
+            params,
+        })
+    }
+}
+
+test('Headless API: NSPage', () => {
+    const api = new HeadlessRoadizApi(process.env.API_BASE_URL, process.env.API_NON_PREVIEW_API_KEY, false)
+
+    return api.getPages({
+        order: {
+            'node.position': 'ASC'
+        }
+    }).then((response) => {
+        expect(response.status).toBe(200)
+        expect(response.data["hydra:member"][0]).toBeDefined()
+        expect(response.data["hydra:member"][0]['@type']).toBe('Page')
+
+        response.data["hydra:member"].forEach((page: NSPage) => {
+            expect(page.url).toContain('/')
+            page.image.forEach((document: RoadizDocument) => {
+                expect(document.url).toContain('/files')
+            })
+        })
+    })
+})
+
+test('Headless API: By path', () => {
+    const api = new HeadlessRoadizApi(process.env.API_BASE_URL, process.env.API_NON_PREVIEW_API_KEY, false)
+
+    return api.getSingleNodesSourcesByPath('/').then((response) => {
+        expect(response.status).toBe(200)
+        expect(response.data).toBeDefined()
+        expect(response.data['@type']).toBe('Page')
+        expect(response.data.url).toBe('/')
+    })
+})
+
+test('Headless API: NSNeutral', () => {
+    const api = new HeadlessRoadizApi(process.env.API_BASE_URL, process.env.API_NON_PREVIEW_API_KEY, false)
+
+    return api.getNeutrals({
+        page: 1
+    }).then((response) => {
+        expect(response.status).toBe(200)
+        expect(response.data["hydra:member"][0]).toBeDefined()
+        expect(response.data["hydra:member"][0]['@type']).toBe('Neutral')
+    })
+})

--- a/tests/InheritingRoadizApi.test.ts
+++ b/tests/InheritingRoadizApi.test.ts
@@ -55,7 +55,7 @@ test('Headless API: Sitemap FR', () => {
 
     return api.fetchAllUrlsForLocale('fr').then((urls) => {
         urls.forEach((url: string) => {
-            expect(url).toContain('/fr')
+            expect(url).toContain('/')
         })
     })
 })

--- a/tests/InheritingRoadizApi.test.ts
+++ b/tests/InheritingRoadizApi.test.ts
@@ -1,20 +1,20 @@
 import RoadizApi from '../src/RoadizApi'
-import {RoadizApiNSParams} from '../types/roadiz-api'
-import {AxiosResponse} from "axios"
-import {HydraCollection} from '../types/hydra'
+import {RoadizApiNSParams, RoadizApiTagsParams} from '../types/roadiz-api'
 import {NSNeutral, NSPage} from "./types/roadiz-app-20210623-220029"
 import {RoadizDocument} from "../types/roadiz";
 
 class HeadlessRoadizApi extends RoadizApi {
-    getPages(params: RoadizApiNSParams): Promise<AxiosResponse<HydraCollection<NSPage>>> {
-        return this.axios.get<HydraCollection<NSPage>>(`/page`, {
-            params,
-        })
+    getPages(params: RoadizApiNSParams) {
+        return this.getNodesSourcesForType<NSPage>('page', params)
     }
-    getNeutrals(params: RoadizApiNSParams): Promise<AxiosResponse<HydraCollection<NSNeutral>>> {
-        return this.axios.get<HydraCollection<NSNeutral>>(`/neutral`, {
-            params,
-        })
+    getPagesTags(params: RoadizApiTagsParams) {
+        return this.getTagsForType('page', params)
+    }
+    getNeutrals(params: RoadizApiNSParams) {
+        return this.getNodesSourcesForType<NSNeutral>('neutral', params)
+    }
+    getNeutralsTags(params: RoadizApiTagsParams) {
+        return this.getTagsForType('neutral', params)
     }
 }
 
@@ -47,6 +47,26 @@ test('Headless API: By path', () => {
         expect(response.data).toBeDefined()
         expect(response.data['@type']).toBe('Page')
         expect(response.data.url).toBe('/')
+    })
+})
+
+test('Headless API: Sitemap FR', () => {
+    const api = new HeadlessRoadizApi(process.env.API_BASE_URL, process.env.API_NON_PREVIEW_API_KEY, false)
+
+    return api.fetchAllUrlsForLocale('fr').then((urls) => {
+        urls.forEach((url: string) => {
+            expect(url).toContain('/fr')
+        })
+    })
+})
+
+test('Headless API: Sitemap EN', () => {
+    const api = new HeadlessRoadizApi(process.env.API_BASE_URL, process.env.API_NON_PREVIEW_API_KEY, false)
+
+    return api.fetchAllUrlsForLocale('en').then((urls) => {
+        urls.forEach((url: string) => {
+            expect(url).toContain('/')
+        })
     })
 })
 

--- a/tests/RoadizApi.test.ts
+++ b/tests/RoadizApi.test.ts
@@ -1,0 +1,72 @@
+import RoadizApi from '../src/RoadizApi'
+import {AxiosError} from 'axios'
+
+test('Non-configured API is not found', () => {
+    const api = new RoadizApi('http://nope.test/api/1.0', 'xxxx', false)
+
+    return api.getNodesSources({
+        page: 1
+    }).catch((reason: AxiosError) => {
+        expect(reason.response).toBeUndefined()
+    })
+})
+
+test('Bad api key API', () => {
+    const api = new RoadizApi(process.env.API_BASE_URL, 'xxxxxx', false)
+
+    return api.getNodesSources({
+        page: 1
+    }).catch((response: AxiosError) => {
+        expect(response.response.status).toBe(403)
+    })
+})
+
+test('Configured API', () => {
+    const api = new RoadizApi(process.env.API_BASE_URL, process.env.API_NON_PREVIEW_API_KEY, false)
+
+    return api.getNodesSources({
+        page: 1
+    }).then((response) => {
+        expect(response.status).toBe(200)
+    })
+})
+
+test('Test NodesSources HydraCollection response', () => {
+    const api = new RoadizApi(process.env.API_BASE_URL, process.env.API_NON_PREVIEW_API_KEY, false)
+
+    return api.getNodesSources({}).then((response) => {
+        expect(response.data["hydra:totalItems"]).toBeGreaterThan(1)
+        expect(response.data["hydra:member"][0]).toHaveProperty('@type')
+        expect(response.data["hydra:member"][0]).toHaveProperty('slug')
+    })
+})
+
+test('Test CommonContent Response HydraCollection response', () => {
+    const api = new RoadizApi(process.env.API_BASE_URL, process.env.API_NON_PREVIEW_API_KEY, false)
+
+    return api.getNodesSources({}).then((response) => {
+        expect(response.data["hydra:totalItems"]).toBeGreaterThan(1)
+        expect(response.data["hydra:member"][0]).toHaveProperty('@type')
+        expect(response.data["hydra:member"][0]).toHaveProperty('slug')
+    })
+})
+
+test('Bad Api key preview API', () => {
+    const api = new RoadizApi(process.env.API_BASE_URL, process.env.API_NON_PREVIEW_API_KEY, true)
+
+    return api.getNodesSources({
+        page: 1
+    }).catch((response: AxiosError) => {
+        expect(response.response.status).toBe(403)
+    })
+})
+
+test('Configured preview API', () => {
+    const api = new RoadizApi(process.env.API_BASE_URL, process.env.API_PREVIEW_API_KEY, true)
+
+    return api.getNodesSources({
+        page: 1
+    }).then((response) => {
+        expect(response.status).toBe(200)
+    })
+})

--- a/tests/types/roadiz-app-20210623-220029.d.ts
+++ b/tests/types/roadiz-app-20210623-220029.d.ts
@@ -1,0 +1,57 @@
+/*
+ * This is an automated Roadiz interface declaration file.
+ * RoadizNodesSources, RoadizDocument and other mentioned types are part of
+ * roadiz/abstract-api-client package which must be installed in your project.
+ *
+ * @see https://github.com/roadiz/abstract-api-client
+ *
+ * Roadiz CMS node-types interfaces
+ *
+ * @see https://docs.roadiz.io/en/latest/developer/nodes-system/intro.html#what-is-a-node-type
+ */
+
+import { RoadizDocument, RoadizNodesSources } from '../../types/roadiz'
+
+//
+// Content block
+//
+// Reachable: false
+// Publishable: false
+// Visible: true
+interface NSContentBlock extends RoadizNodesSources {
+    // Content
+    content?: string
+    // Image
+    image: Array<RoadizDocument>
+}
+
+//
+// Neutral
+//
+// Reachable: false
+// Publishable: false
+// Visible: true
+interface NSNeutral extends RoadizNodesSources {
+
+}
+
+//
+// Page
+//
+// Reachable: true
+// Publishable: true
+// Visible: true
+interface NSPage extends RoadizNodesSources {
+    // This node-type uses "blocks" which are available through parent RoadizNodesSources.blocks
+    // Possible block node-types: ContentBlock
+    // Content
+    content?: string
+    // Content
+    intro?: string
+    // Image
+    image: Array<RoadizDocument>
+    // Reference to other page
+    // Group: References
+    // Possible values: Page
+    pageReference: Array<NSPage>
+}

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -1,4 +1,4 @@
-import { RoadizHead, RoadizWalker } from "./roadiz";
+import { RoadizHead, RoadizWalker } from './roadiz'
 
 export interface CommonContentResponse {
     head: RoadizHead

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -1,0 +1,7 @@
+import { RoadizHead, RoadizWalker } from "./roadiz";
+
+export interface CommonContentResponse {
+    head: RoadizHead
+    mainMenuWalker?: RoadizWalker
+    '@type': string
+}

--- a/types/hydra.d.ts
+++ b/types/hydra.d.ts
@@ -1,3 +1,5 @@
+import {RoadizArchivesList} from './roadiz'
+
 /**
  * Hydra JSON-LD collection interface
  *
@@ -6,6 +8,12 @@
 
 export interface HydraCollection<T> {
     'hydra:member': Array<T>
+    'hydra:totalItems': number
+    'hydra:view': HydraView
+}
+
+export interface ArchivesHydraCollection {
+    'hydra:member': RoadizArchivesList
     'hydra:totalItems': number
     'hydra:view': HydraView
 }

--- a/types/roadiz-api.d.ts
+++ b/types/roadiz-api.d.ts
@@ -3,20 +3,23 @@
  *
  * @see https://github.com/roadiz/AbstractApiTheme/blob/develop/README.md#listing-nodes-sources
  */
-export interface RoadizApiNSParams {
+export interface RoadizApiBaseParams {
     itemsPerPage?: number
     page?: number
     _preview?: boolean
     _locale?: string
+    properties?: string[]
+}
+
+export interface RoadizApiNSParams extends RoadizApiBaseParams {
     search?: string
     order?: {
         [key: string]: 'ASC' | 'DESC'
     }
     archive?: string
     path?: string
-    properties?: string[]
     id?: number
-    title?: number
+    title?: string
     publishedAt?: RoadizApiPublishedParams
     tags?: Array<string>
     tagExclusive?: boolean
@@ -32,9 +35,32 @@ export interface RoadizApiNSParams {
     'node.bNodes.field.name'?: string
 }
 
+export interface RoadizApiTagsParams extends RoadizApiBaseParams {
+    search?: string
+    order?: {
+        [key: string]: 'ASC' | 'DESC'
+    }
+    tagName?: string
+    publishedAt?: RoadizApiPublishedParams
+    parent?: string | number
+    visible?: boolean
+}
+
 export interface RoadizApiPublishedParams {
     after?: string
     before?: string
     strictly_after?: string
     strictly_before?: string
+}
+
+export interface RoadizApiSearchParams extends RoadizApiBaseParams {
+    search?: string
+    archive?: string
+    id?: number
+    title?: string
+    tags?: Array<string>
+    publishedAt?: RoadizApiPublishedParams
+    'node.nodeType'?: string | Array<string>
+    'node.parent'?: string | number
+    'node.visible'?: boolean
 }

--- a/types/roadiz-api.d.ts
+++ b/types/roadiz-api.d.ts
@@ -20,7 +20,7 @@ export interface RoadizApiNSParams {
     publishedAt?: RoadizApiPublishedParams
     tags?: Array<string>
     tagExclusive?: boolean
-    not?: int | string | Array<int | string>
+    not?: number | string | Array<number | string>
     'node.parent'?: string | number
     'node.visible'?: boolean
     'node.home'?: boolean

--- a/types/roadiz-api.d.ts
+++ b/types/roadiz-api.d.ts
@@ -3,6 +3,11 @@
  *
  * @see https://github.com/roadiz/AbstractApiTheme/blob/develop/README.md#listing-nodes-sources
  */
+interface AlternateLink {
+    url: string
+    locale: string
+}
+
 export interface RoadizApiBaseParams {
     itemsPerPage?: number
     page?: number

--- a/types/roadiz.d.ts
+++ b/types/roadiz.d.ts
@@ -51,6 +51,14 @@ export interface RoadizSearchResultItem {
     highlighting?: RoadizSearchHighlighting
 }
 
+export interface RoadizArchivesYear {
+    [key: string]: string
+}
+
+export interface RoadizArchivesList {
+    [key: string]: RoadizArchivesYear
+}
+
 export interface RoadizHead {
     facebookUrl?: string
     twitterUrl?: string

--- a/types/roadiz.d.ts
+++ b/types/roadiz.d.ts
@@ -40,6 +40,17 @@ export interface RoadizNodesSources {
     '@id'?: string
 }
 
+export interface RoadizSearchHighlighting {
+    collection_txt?: string[]
+    collection_txt_fr?: string[]
+    collection_txt_en?: string[]
+}
+
+export interface RoadizSearchResultItem {
+    nodeSource?: RoadizNodesSources
+    highlighting?: RoadizSearchHighlighting
+}
+
 export interface RoadizHead {
     facebookUrl?: string
     twitterUrl?: string

--- a/types/roadiz.d.ts
+++ b/types/roadiz.d.ts
@@ -34,9 +34,27 @@ export interface RoadizNodesSources {
     metaKeywords?: string
     metaDescription?: string
     blocks?: Array<RoadizWalker>
+    head?: RoadizHead
     urlAliases?: Array<RoadizUrlAlias>
     '@type': string
     '@id'?: string
+}
+
+export interface RoadizHead {
+    facebookUrl?: string
+    twitterUrl?: string
+    linkedinUrl?: string
+    instagramUrl?: string
+    youtubeUrl?: string
+    shareImage?: RoadizDocument
+    googleAnalytics?: string
+    googleTagManager?: string
+    matomoUrl?: string
+    matomoSiteId?: string
+    policyUrl?: string
+    siteName?: string
+    mainColor?: string
+    homePageUrl?: string
 }
 
 export interface RoadizUrlAlias {

--- a/types/roadiz.d.ts
+++ b/types/roadiz.d.ts
@@ -41,8 +41,11 @@ export interface RoadizNodesSources {
 }
 
 export interface RoadizSearchHighlighting {
+    // eslint-disable-next-line camelcase
     collection_txt?: string[]
+    // eslint-disable-next-line camelcase
     collection_txt_fr?: string[]
+    // eslint-disable-next-line camelcase
     collection_txt_en?: string[]
 }
 


### PR DESCRIPTION
- Added unit test with JEST but requires a live Roadiz API
- `RoadizApi` class to be extended with custom types from a real API 
- Easily extendable methods with Typescript generics